### PR TITLE
Check for mislabeled platforms

### DIFF
--- a/modio_repo/downloader/pallets.py
+++ b/modio_repo/downloader/pallets.py
@@ -108,7 +108,7 @@ class PalletHandler(Generic[T]):
                     )
                     async with aiofiles.open(fs_path, "wb+") as f:
                         await f.write(zf.read(pfile))
-                        platform = await self._get_platform(file_like)
+                        platform = await self._get_platform(zf)
                         found_pallets.append((path_in_zf, fs_path, platform))
             if len(found_pallets) < 0:
                 raise PalletLoadError(
@@ -122,11 +122,7 @@ class PalletHandler(Generic[T]):
                 self.modio_file_id,
             ) from e
 
-    async def _get_platform(self, file_like) -> ModPlatform:
-        try:
-            zf = ZipFile(file_like)
-        except BadZipfile as e:
-            raise PalletLoadError(str(e), self.modio_file_id)
+    async def _get_platform(self, zf) -> ModPlatform:
         try:
             file_list = zf.infolist()
             for pfile in file_list:

--- a/modio_repo/downloader/pallets.py
+++ b/modio_repo/downloader/pallets.py
@@ -49,8 +49,6 @@ class PalletHandler(Generic[T]):
         pallet_list = await self.get_from_zip(file_obj)
 
         for zf_path, fs_path , mod_platform in pallet_list:
-            if mod_platform != web_platform:
-                raise PalletLoadError("Possible Platform mismatch", -999)
             
             data = self.get_pallet_content(fs_path)
 
@@ -63,6 +61,8 @@ class PalletHandler(Generic[T]):
                 fs_path=str(fs_path),
                 file=self.file,
             )
+            if mod_platform != web_platform:
+                raise PalletLoadError("Multiple Platforms or Platform Mismatch", self.modio_file_id)
             await db_pallet.save()
 
     def get_pallet_class(self):


### PR DESCRIPTION
Raises `PalletLoadError` when there are multiple pallets in one zip and when the platform is mislabeled on mod.io

Fixes #3